### PR TITLE
Changed comparison function to avoid floating point comparison errors

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -1749,7 +1749,7 @@ plotRegulation <- function(netPhorceData = netPhorceData,
                            plotly = TRUE){
   data.significant.proteins = netPhorceData@regulationData
   regColors = netPhorceData@Misc$colors_Reg
-  filteredData <- data.significant.proteins %>% filter(avgValue != 0) %>% filter(avgValue != change)
+  filteredData <- data.significant.proteins %>% filter(avgValue != 0) %>% filter(!near(avgValue,change))
   filteredData$sigChangeSign <- as.character(filteredData$sigChangeSign)
   ## Check Condition
   ConDesign <- netPhorceData@Design$ConDesign


### PR DESCRIPTION
Recently with a dataset I observed several points being plotted by `plotRegulation()` had a very strange distribution. It looked like a straight line overlaid on the typical blob near the origin. I traced this back to `plotRegulation()` and this line in `plotting.R` (edited below), where a filter is applied to only accept points where `avgValue != change` is true. In the case of the weird points on the graph, I believe they occur when there's a gap in a timecourse. The math of the fold-change calculation over timepoints doesn't make sense if that's true, and the avgValue and change values should be identical in that case. I'm assuming that's why that check is in the filter. Anyway, in my case, the two values being compared differed by about 9e-18--floating point error--so those points were passing this strict inequality check when they shouldn't. I believe this expression needs to be replaced with a dedicated function for float equality. Tidyverse offers the `near()` function for this purpose.

There may be more places in the codebase where similar modifications are indicated, but most of the comparisons are between integers/characters/factors/bools, not floats. I have not done a comprehensive review, though.